### PR TITLE
test: verificar o título da aplicação

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -1,5 +1,6 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
+describe('Central de Atendimento ao Cliente TAT', () => {
+  it('verifica o título da aplicação', () => {
+    cy.visit('./src/index.html')
+    cy.title().should('be.equal', 'Central de Atendimento ao Cliente TAT')
   })
 })


### PR DESCRIPTION
- Acessa a página da aplicação com cy.visit()
- Armazena o título da aplicação com cy.title()
- Verifica se o título da aplicação esta correto com .should('be.equal', 'título da aplicação')