### PR TITLE
test: preenche os campos obrigatórios e envia formulário

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -1,6 +1,19 @@
 describe('Central de Atendimento ao Cliente TAT', () => {
-  it('verifica o título da aplicação', () => {
+ 
+  beforeEach(()=>{
     cy.visit('./src/index.html')
+  })
+  it('verifica o título da aplicação', () => {
     cy.title().should('be.equal', 'Central de Atendimento ao Cliente TAT')
+  })
+
+  it('preenche os campos obrigatórios e envia o formulário', ()=>{
+    cy.get('#firstName').type( 'Pomposo')
+    cy.get('#lastName').type('Silva')
+    cy.get('#email').type('pomposo-silva@gmail.com')
+    cy.get('#open-text-area').type('QA teste plataforma CAC-TAT')
+    cy.get('button[type="submit"]').click()
+
+    cy.get('.success').should('be.visible')
   })
 })


### PR DESCRIPTION
- Move o comando `cy.visit()` para um bloco `beforeEach()`
- Adiciona novo cenário para preencher os campos obrigatórios e enviar o formulário
- Verifica se a mensagem de sucesso é exibida corretamente
