### PR TITLE
test: otimiza preenchimento do text-area removendo delay

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -8,10 +8,11 @@ describe('Central de Atendimento ao Cliente TAT', () => {
   })
 
   it('preenche os campos obrigatórios e envia o formulário', ()=>{
+    const longText = Cypress._.repeat('QA teste plataforma CAC-TAT ', 15)
     cy.get('#firstName').type( 'Pomposo')
     cy.get('#lastName').type('Silva')
     cy.get('#email').type('pomposo-silva@gmail.com')
-    cy.get('#open-text-area').type('QA teste plataforma CAC-TAT')
+    cy.get('#open-text-area').type(longText, { delay: 0 })
     cy.get('button[type="submit"]').click()
 
     cy.get('.success').should('be.visible')


### PR DESCRIPTION
- Otimiza o preenchimento do campo `text-area` removendo o `delay` no comando `.type()`.
- Utiliza `Cypress._.repeat()` (Lodash) para repetir os dados inseridos no `text-area`, tornando os testes mais dinâmicos.
- Melhora a performance do teste ao reduzir o tempo de digitação simulado.