### PR TITLE
fix: remove  do teste para permitir execução de todos os cenários

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -44,7 +44,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
     });
   });
 
-  it.only('mantém o campo de telefone vazio ao inserir valores não numéricos', () => {
+  it('mantém o campo de telefone vazio ao inserir valores não numéricos', () => {
     cy.get("#phone")
       .type("`˜!@#$%ˆ&* ()_-+={[}];:'<,>.?/abcA")
       .should('be.empty')


### PR DESCRIPTION
- Removido `.only` do teste, garantindo que todos os cenários sejam executados corretamente no Cypress.
- Agora, a suite de testes não ficará restrita a um único cenário, permitindo uma cobertura completa.
