### PR TITLE
test: valida mensagem de erro ao submeter o formulário sem preencher …

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -93,4 +93,11 @@ describe("Central de Atendimento ao Cliente TAT", () => {
       .should('be.empty')
   })
 
+  it('exibe mensagem de erro ao submeter o formulário sem preencher os campos obrigatórios.', ()=> {
+    cy.get('button[type="submit"]').click();
+
+    cy.get('.sucess').should('not.be.exist')
+    cy.get('.error').should('be.visible')
+  })
+
 });


### PR DESCRIPTION
- Valida a exibição da mensagem de erro ao submeter o formulário sem preencher os campos obrigatórios.
- Garante que a validação ocorre corretamente e impede o envio do formulário quando campos obrigatórios estão vazios.
- Assegura que a mensagem de erro seja exibida de forma visível para o usuário.
