### PR TITLE
test: valida a seleção de um arquivo da pasta fixtures

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -158,5 +158,13 @@ describe("Central de Atendimento ao Cliente TAT", () => {
       .uncheck()
       .should('not.be.checked')
   })
-     
+
+  it('seleciona um arquivo da pasta fixtures', ()=> {
+    cy.get('#file-upload')
+      .selectFile('cypress/fixtures/example.json')
+      .then( (input)=> {
+        expect(input[0].files[0].name).to.equal('example.json')
+      })
+  })
+   
 })


### PR DESCRIPTION
- Garante que um arquivo da pasta `fixtures` pode ser selecionado corretamente
- Valida que o nome do arquivo é persistido no objeto `files` do input
