### PR TITLE
fix: adiciona validação do nome do arquivo no upload via drag-and-drop

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -141,6 +141,9 @@ describe("Central de Atendimento ao Cliente TAT", () => {
 
   it("seleciona um arquivo simulando um drag-and-drop", () => {
     cy.get("#file-upload").selectFile("cypress/fixtures/example.json", { action: 'drag-drop' })
+      .then((input)=> {
+        expect(input[0].files[0].name).to.equal('example.json')
+      })
   });
   
 });


### PR DESCRIPTION
- Adiciona a validação do nome do arquivo selecionado no input de upload
- Usa `.then()` para garantir que o nome do arquivo persistiu corretamente após o `drag-drop`
- Evita falsos positivos garantindo que o arquivo correto foi processado
