### PR TITLE
refact: adiciona null nas fixtures para evitar conversão automática

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -133,14 +133,14 @@ describe("Central de Atendimento ao Cliente TAT", () => {
 
   it("seleciona um arquivo da pasta fixtures", () => {
     cy.get("#file-upload")
-      .selectFile("cypress/fixtures/example.json")
+      .selectFile("cypress/fixtures/example.json", null)
       .then((input) => {
         expect(input[0].files[0].name).to.equal("example.json");
       });
   });
 
   it("seleciona um arquivo simulando um drag-and-drop", () => {
-    cy.get("#file-upload").selectFile("cypress/fixtures/example.json", { action: 'drag-drop' })
+    cy.get("#file-upload").selectFile("cypress/fixtures/example.json",null , { action: 'drag-drop' })
       .then((input)=> {
         expect(input[0].files[0].name).to.equal('example.json')
       })


### PR DESCRIPTION
- Padroniza o uso de cy.fixture() com null para evitar a conversão automática de JSON ao selecionar arquivos em testes de upload e drag-and-drop.