### PR TITLE
test: valida exibição e ocultação de alertas de sucesso e erro

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -174,7 +174,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
       });
   });
 
-  it.only("exibe e oculta as mensagens de sucesso e erro usando .invoke()", () => {
+  it("exibe e oculta as mensagens de sucesso e erro usando .invoke()", () => {
     cy.validateAlertVisibility(".success");
     cy.validateAlertVisibility(".error");
   });

--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -8,7 +8,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
   });
 
   it("preenche os campos obrigatórios e envia o formulário", () => {
-    cy.clock()
+    cy.clock();
     const longText = Cypress._.repeat("QA teste plataforma CAC-TAT ", 15);
     cy.get("#firstName").type("Pomposo");
     cy.get("#lastName").type("Silva");
@@ -17,7 +17,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
     cy.contains("button", "Enviar").click();
 
     cy.get(".success").should("be.visible");
-    cy.tick(3000)
+    cy.tick(3000);
     cy.get(".success").should("not.be.visible");
   });
 
@@ -31,8 +31,8 @@ describe("Central de Atendimento ao Cliente TAT", () => {
 
   invalidEmails.forEach((email) => {
     it(`exibe mensagem de erro ao submeter e-mails inválidos ${email}`, () => {
-      cy.clock()
-      
+      cy.clock();
+
       cy.get("#firstName").type("Cremoso");
       cy.get("#lastName").type("Pompeu");
       cy.get("#email").type(email);
@@ -40,11 +40,11 @@ describe("Central de Atendimento ao Cliente TAT", () => {
       cy.contains("button", "Enviar").click();
 
       cy.get(".error").should("be.visible");
-      cy.get(".sucess").should('not.exist')
-      cy.tick(3000)
+      cy.get(".sucess").should("not.exist");
+      cy.tick(3000);
 
       cy.get(".error").should("not.be.visible");
-      cy.get(".sucess").should('not.exist')
+      cy.get(".sucess").should("not.exist");
 
       cy.get("#email").clear();
     });
@@ -57,7 +57,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
   });
 
   it("exibe mensagem de erro quando o telefone se torna obrigatório mas não é preenchido antes do envio do formulário", () => {
-    cy.clock()
+    cy.clock();
     const longText = Cypress._.repeat("QA teste plataforma CAC-TAT ", 15);
     cy.get("#firstName").type("Pomposo");
     cy.get("#lastName").type("Silva");
@@ -70,7 +70,7 @@ describe("Central de Atendimento ao Cliente TAT", () => {
     cy.get("#phone").should("have.value", "");
     cy.get("#phone").should("have.attr", "required");
     cy.get(".error").should("be.visible");
-    cy.tick(3000)
+    cy.tick(3000);
     cy.get(".error").should("not.be.visible");
   });
 
@@ -89,24 +89,23 @@ describe("Central de Atendimento ao Cliente TAT", () => {
   });
 
   it("exibe mensagem de erro ao submeter o formulário sem preencher os campos obrigatórios.", () => {
-    cy.clock()
+    cy.clock();
     cy.contains("button", "Enviar").click();
 
     cy.get(".sucess").should("not.be.exist");
     cy.get(".error").should("be.visible");
 
-    cy.tick(3000)
+    cy.tick(3000);
     cy.get(".sucess").should("not.be.exist");
     cy.get(".error").should("not.be.visible");
-
   });
 
   it("envia o formuário com sucesso usando um comando customizado", () => {
-    cy.clock()
+    cy.clock();
     cy.fillMandatoryFieldsAndSubmit();
 
     cy.get(".success").should("be.visible");
-    cy.tick(3000)
+    cy.tick(3000);
     cy.get(".success").should("not.be.visible");
   });
 
@@ -157,19 +156,26 @@ describe("Central de Atendimento ao Cliente TAT", () => {
   });
 
   it("seleciona um arquivo simulando um drag-and-drop", () => {
-    cy.get("#file-upload").selectFile("cypress/fixtures/example.json",null , { action: 'drag-drop' })
-      .then((input)=> {
-        expect(input[0].files[0].name).to.equal('example.json')
+    cy.get("#file-upload")
+      .selectFile("cypress/fixtures/example.json", null, {
+        action: "drag-drop",
       })
+      .then((input) => {
+        expect(input[0].files[0].name).to.equal("example.json");
+      });
   });
 
-  it('seleciona um arquivo utilizando uma fixture para a qual foi dada um alias', ()=> {
-    cy.fixture("example.json", null).as('dataFixture')
+  it("seleciona um arquivo utilizando uma fixture para a qual foi dada um alias", () => {
+    cy.fixture("example.json", null).as("dataFixture");
     cy.get("#file-upload")
-      .selectFile('@dataFixture')
-      .then((data)=>{
-        expect(data[0].files[0].name).to.equal('example.json')
-      })
-  })
-  
+      .selectFile("@dataFixture")
+      .then((data) => {
+        expect(data[0].files[0].name).to.equal("example.json");
+      });
+  });
+
+  it.only("exibe e oculta as mensagens de sucesso e erro usando .invoke()", () => {
+    cy.validateAlertVisibility(".success");
+    cy.validateAlertVisibility(".error");
+  });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,3 +36,14 @@ Cypress.Commands.add('fillMandatoryFieldsAndSubmit', ( dataField = {
     cy.get("#open-text-area").type(dataField.description, { delay: 0 })
     cy.contains('button', 'Enviar').click();
 })
+
+Cypress.Commands.add('validateAlertVisibility', (element)=> {
+    cy.get(element)
+        .invoke('show')
+        .should('be.visible')
+    
+        cy.get(element)
+        .invoke('hide')
+        .should('not.be.visible')
+        
+})


### PR DESCRIPTION
- Criado novo teste para validar a exibição e ocultação de alertas de sucesso e erro.
- Implementado um Custom Command (`validateAlertVisibility`) para tornar o teste mais reutilizável.
- Removido `.only` dos testes para garantir que todos sejam executados na suite.
