### PR TITLE
test: revela imagem oculta do gato com .invoke()

### DIFF
--- a/cypress/e2e/CAC-TAT.cy.js
+++ b/cypress/e2e/CAC-TAT.cy.js
@@ -200,4 +200,14 @@ describe("Central de Atendimento ao Cliente TAT", () => {
 
   });
 
+  it('revela imagem oculta do gato', ()=> {
+    cy.get('#cat').as('imageCat'); // Arrange
+    cy.get('@imageCat').should('not.be.visible');
+
+    cy.get('@imageCat').invoke('show'); // Act
+
+    cy.get('@imageCat').should('be.visible'); // Assert
+
+  })
+
 });


### PR DESCRIPTION
- Validado que a imagem do gato inicialmente está oculta.
- Utilizado `.invoke('show')` para forçar a exibição da imagem.
- Verificado que a imagem ficou visível após a ação.
